### PR TITLE
Reorganize

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [info@milspousecoders.org]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,20 @@
-Alright MilSpouse Coders, we’re going to break you into the magic of GitHub and contributing to a repo!
+# Contributing to MilSpouseCoders Hacktoberfest_2020
 
-## Step 1: Fork the repository
+MilSpouse Coders, we’re going to break you into the magic of GitHub and contributing to a repo!
 
--   This first thing you want to do is fork this repository. This will create a copy of this repository in your personal GitHub account.
+## Table Of Contents
 
-## Step 2: Clone the repository
+* [Code of Conduct](#code-of-conduct)
 
--   The second step is to get the repository onto your personal machine, this is called cloning.
--   Go to your personal GitHub account and click the green button that says, “Clone or Download”.
--   (Which method do we suggest? Terminal or using GitHub desktop? Or do we make sure they know how to do both?)
+* [How to Contribute](#how-to-contribute)
 
-## Step 3: Create a branch
+### Code of Conduct
 
--   The third step of this process is to create your own branch. When collaborating we don’t work directly on the Master branch, we keep our work separate and then submit it with the hope that it will eventually be merged into the Master branch.
+This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [info@milspousecoders.org](mailto:info@milspousecoders.org).
 
-## Step 4: Make a change to the AddYourNameHere.MD file
+### How to Contribute
 
--   Now that you have your own branch it’s time to add your name to the appropriate file. Make sure you have the project opened your code editor and open up the file named AddYourNameHere.MD. There is no coding here, you’re just typing your GitHub name. After you’ve added your name, save the file.
+* [Command Line](command-line-tutorial.md)
+* [GitHub Desktop](github-desktop-tutorial.md)
 
-## Step 5: Push changes to GitHub
-
--   You created a new branch and added to a file, so now it’s time to add those changes to your personal GitHub forked copy. You will be pushing those changes to your GitHub account.
--   Add a useful comment or description of the changes you made.
--   Push via the method that you’re using.
-
-## Step 6: Create pull request & submit it
-
--   The final step is to say to the maintainers of the MSC Hacktoberfest_2020 repo, “Hey, I made an addition to your repo, please take a look at it! And, if it’s good enough, merge it into the master branch!”
--   Go to the repository on your personal GitHub and click the “Compare & Pull Request” button.
--   The comment/description that you added in the Push process should be shown. You are able to add additional comments at this point.
--   Click the “Create Pull Request” button and you’re done! The maintainers of the repo will take a look at it and if you did It right, your changes will be merged into the master branch of the repo.
+This guide to contributing is adapted from [Atom](https://github.com/atom/atom/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -8,17 +8,16 @@
 
 -   This repo is geared toward first time contributors, specifically our MilSpouse Coders family.
 
-# Links to:
+# Let's get started!
 
--   Installing Git on your machine
--   Creating a GitHub account
--   GitHub Desktop
--   Visual Studio Code
--   Udacity instructional Course
--   GitHub Cheat Sheet: https://education.github.com/git-cheat-sheet-education.pdf
+* We are going to provide tutorials for two methods of contributing to this repository: Command Line and GitHub Desktop.  For either method you will need a GitHub account: https://github.com/
 
-# This project was inspired by:
+* If you prefer to work from the command line, see this tutorial: https://github.com/MilSpouseCoders/Hacktoberfest_2020/command-line-tutorial.md
 
+* If you prefer to use the GitHub Desktop App, see this tutorial: https://github.com/MilSpouseCoders/Hacktoberfest_2020/github-desktop-tutorial.md
+
+This project was inspired by:
 [First-Contributions](https://github.com/firstcontributions/first-contributions)
 
 This project is licensed under the terms of the MIT license ([License](https://github.com/MilSpouseCoders/Hacktoberfest_2020#license)).
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # This project was inspired by:
 
-[First-Contributions](https://github.com/firstcontributions/first-contributions#tutorials-using-other-tools)
+[First-Contributions](https://github.com/firstcontributions/first-contributions)
 
 # [License](https://github.com/codercarly/Hacktoberfest_2020#license)
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,4 @@
 
 [First-Contributions](https://github.com/firstcontributions/first-contributions)
 
-#### _If you're not comfortable with command line, [here are tutorials using GUI tools.](#tutorials-using-other-tools)_
-
-## Tutorials Using Other Tools
-
-<a href="github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a>
-
 This project is licensed under the terms of the MIT license ([License](https://github.com/MilSpouseCoders/Hacktoberfest_2020#license)).

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@
 
 * We are going to provide tutorials for two methods of contributing to this repository: Command Line and GitHub Desktop.  For either method you will need a GitHub account: https://github.com/
 
-* If you prefer to work from the command line, see this tutorial: https://github.com/MilSpouseCoders/Hacktoberfest_2020/command-line-tutorial.md
-
-* If you prefer to use the GitHub Desktop App, see this tutorial: https://github.com/MilSpouseCoders/Hacktoberfest_2020/github-desktop-tutorial.md
+* Please see [Contributing](CONTRIBUTING.md) for guidelines on how to contribute to this repository.
 
 This project was inspired by:
 [First-Contributions](https://github.com/firstcontributions/first-contributions)

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
 
 [First-Contributions](https://github.com/firstcontributions/first-contributions)
 
-# [License](https://github.com/codercarly/Hacktoberfest_2020#license)
-
 #### _If you're not comfortable with command line, [here are tutorials using GUI tools.](#tutorials-using-other-tools)_
 
 ## Tutorials Using Other Tools
 
 <a href="github-desktop-tutorial.md"><img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="100"></a>
+
+This project is licensed under the terms of the MIT license ([License](https://github.com/MilSpouseCoders/Hacktoberfest_2020#license)).

--- a/command-line-tutorial.md
+++ b/command-line-tutorial.md
@@ -1,0 +1,111 @@
+[![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+
+
+Making your first contribution using the command line
+======================================================
+
+## 1. If you don't have git on your machine: 
+* [Install Git](https://git-scm.com/downloads)
+* Set your user name: ```git config --global user.name "Mona Lisa"```
+
+
+* Set your commit email: ```git config --global user.email "email@example.com"```
+
+## 2. Fork this repository
+
+Fork this repository by clicking on the fork button on the top of this page.
+This will create a copy of this repository in your account.
+
+<img style="left" src="assets/fork.png" alt="fork this repository" />
+
+## 3. Clone the repository
+
+Now clone the forked repository to your machine. Go to your GitHub account, open the forked repository, click on the clone button and then click the *copy to clipboard* icon.
+
+<img style="left"  src="assets/clone.png" alt="clone this repository" />
+
+Open a terminal and run the following git command:
+
+```
+git clone "url you just copied"
+```
+where "url you just copied" (without the quotation marks) is the url to this repository (your fork of this project). See the previous steps to obtain the url. 
+
+<img align="right" width="300" src="assets/copy-to-clipboard.png" alt="copy URL to clipboard" />
+
+For example:
+```
+git clone https://github.com/this-is-you/hacktoberfest_2020.git
+```
+where `this-is-you` is your GitHub username. Here you're copying the contents of the hacktoberfest_2020 repository on GitHub to your computer.
+
+## 4. Create a branch
+
+Change to the repository directory on your computer (if you are not already there):
+
+```
+cd hacktoberfest_2020
+```
+Now create a branch using the `git checkout` command:
+```
+git checkout -b <add-your-new-branch-name>
+```
+
+For example:
+```
+git checkout -b add-alonzo-church
+```
+(The name of the branch does not need to have the word *add* in it, but it's a reasonable thing to include because the purpose of this branch is to add your name to a list.)
+
+## 5. Make necessary changes and commit those changes
+
+Now open `Contributors.md` file in a text editor, add your name to it. Don't add it at the beginning or end of the file. Put it anywhere in between. Now, save the file.
+
+<img align="right" width="450" src="assets/git-status.png" alt="git status" />
+
+
+If you go to the project directory and execute the command `git status`, you'll see there are changes.
+
+
+Add those changes to the branch you just created using the `git add` command:
+
+```
+git add Contributors.md
+```
+
+Now commit those changes using the `git commit` command:
+```
+git commit -m "Add <your-name> to Contributors list"
+```
+replacing `<your-name>` with your name.
+
+## 6. Push changes to GitHub
+
+Push your changes using the command `git push`:
+```
+git push origin <add-your-branch-name>
+```
+replacing `<add-your-branch-name>` with the name of the branch you created earlier.
+
+## 7. Submit your changes for review
+
+If you go to your repository on GitHub, you'll see a  `Compare & pull request` button. Click on that button.
+
+<img style="float: right;" src="assets/compare-and-pull.png" alt="create a pull request" />
+
+Now submit the pull request.
+
+<img style="float: right;" src="assets/submit-pull-request.png" alt="submit pull request" />
+
+Soon I'll be merging all your changes into the master branch of this project. You will get a notification email once the changes have been merged.
+
+## Where to go from here?
+
+Congrats!  You just completed the standard _fork -> clone -> edit -> PR_ workflow that you'll encounter often as a contributor!
+
+## Additional info:
+
+[More info on git installation and setup](https://docs.github.com/en/github/getting-started-with-github/set-up-git)
+
+

--- a/github-desktop-tutorial.md
+++ b/github-desktop-tutorial.md
@@ -1,75 +1,61 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-|<img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="200">|GitHub Desktop Edition|
-|---|---|
+<img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="200">
 
-It's hard. It's always hard the first time you do something. Especially when you are collaborating, making mistakes isn't a comfortable thing. But open source is all about collaboration & working together. We wanted to simplify the way new open-source contributors learn & contribute for the first time.
+Making your first contribution using Github Desktop
+======================================================
 
-Reading articles & watching tutorials can help, but what comes better than actually doing the stuff without messing up anything. This project aims at providing guidance & simplifying the way rookies make their first contribution. Remember the more relaxed you are the better you learn. If you are looking for making your first contribution just follow the simple steps below. We promise you, it will be fun.
+## 1. If you don't have GitHub Desktop on your machine, [install it](https://desktop.github.com/).
 
-If you don't have GitHub Desktop on your machine, [install it](https://desktop.github.com/).
+## 2. Fork this repository
 
-If you're using a version of GitHub desktop before 1.0, [refer this tutorial](github-desktop-old-version-tutorial.md).
-
-<img align="right" width="300" src="assets/fork.png" alt="fork this repository" />
-
-## Fork this repository
-
-Fork this repo by clicking on the fork button on the top right of this page.
+* Fork this repo by clicking on the fork button on the top right of this page.
 This will create of copy of this repository in your account.
+<img style="left" src="assets/fork.png" alt="fork this repository" />
 
-## Clone the repository
+## 3. Clone the repository to your machine
 
-Now clone this repo to your machine.
+* IMPORTANT: DO NOT CLONE THE ORIGINAL REPO. Go to your fork and clone it.
 
-IMPORTANT: DO NOT CLONE THE ORIGINAL REPO. Go to your fork and clone it.
-
-To clone the repo, click on "Clone or Download" and then click on "Open in Desktop".
-
+* To clone the repo, click on "Clone or Download" and then click on "Open in Desktop".
 <img style="left;" src="assets/dt1-clonetodesktop.png" alt="clone this repository" />
 
-A pop up window will open. Click on "Open GitHubDesktop.exe".
-
+* A pop up window will open. Click on "Open GitHubDesktop.exe".
 <img style="left;" src="assets/dt1-open-githubdesktop.png" alt="clone this repository" />
 
-After you click on "Open GitHubDesktop.exe" the contents will be downloaded to your computer.
-
+* After you click on "Open GitHubDesktop.exe" the contents will be downloaded to your computer.
 <img style="left;" src="assets/dt1-downloaded.png" alt="clone this repository" />
 
-Now you have copied the contents of the first-contributions repository in github to your computer.
+* Now you have copied the contents of the first-contributions repository in github to your computer.
 
-## Create a branch
+## 4. Create a branch
 
-Now create a branch by clicking on the "Current branch" icon at the top and then click on "New branch":
-
+* Now create a branch by clicking on the "Current branch" icon at the top and then click on "New branch":
 <img style="left;" src="assets/dt1-create-branch.png" alt="make a branch" />
 
-Name your branch <add-your-name>. For example, "add-james-smith"
-
+* Name your branch <add-your-github-handle>. For example, "add-james-smith"
 <img style="left;" src="assets/dt1-create-branch-name.png" alt="name your branch" />
 
-Click on `Create branch`
+* Click on `Create branch`
 
-## Make necessary changes and commit those changes
+## 5. Make necessary changes and commit those changes
 
-Now open `Contributors.md` file in a text editor, scroll to the bottom of the page and add your name to it, then save the file.
+* Now open `Contributors.md` file in a text editor, scroll to the bottom of the page and add your GitHub profile link to it, then save the file.
 
-Example: If your name is James Smith, It should look like this.
-
-\[James Smith](https://github.com/jamessmith)
-
-You can see that there are changes to Contributors.md and they have been added to the Github Desktop.
+* Example: If your GitHub handle is jamessmith, It should look like this:
 
 <img style="left;" src="assets/dt1-status.png" alt="check status" />
 
-Now commit those changes:
+* You can see that there are changes to Contributors.md and they have been added to the Github Desktop.
 
-Write the message "Add `<your-name>` to Contributors list" in the *summary* field.
+* Now commit those changes:
 
-Replace `<your-name>` with your name.
+* Write the message "Add `<your-github-handle>` to Contributors list" in the *summary* field.
 
-Click on the button that says `Commit to add-your-name`.
+* Replace `<your-github-handle>` with your GitHub handle.
+
+* Click on the button that says `Commit to add-your-github-handle`.
 
 <img style="left;" src="assets/dt1-commit1.png" alt="commit your changes" />
 
@@ -77,7 +63,7 @@ At the bottom, you can see that the commit has been created.
 
 <img style="left;" src="assets/dt1-commit2.png" alt="commit your changes" />
 
-## Push changes to github
+## 6. Push changes to github
 
 Click on File->Options and sign-in to Github.com. Type in your Github username and password.
 
@@ -87,7 +73,7 @@ Click the `Publish` button on the top right.
 
 <img style="left;" src="assets/dt1-publish1.png" alt="push your changes" />
 
-## Submit your changes for review
+## 7. Submit your changes for review
 
 If you go to your repository on github, you'll see  `Compare & pull request` button. click on that button.
 
@@ -103,26 +89,11 @@ Soon I'll be merging all your changes into the master branch of this project. Yo
 
 Congrats!  You just completed the standard _fork -> clone -> edit -> PR_ workflow that you'll encounter often as a contributor!
 
-Celebrate your contribution and share it with your friends and followers by going to [web app](https://roshanjossey.github.io/first-contributions/#social-share).
+[//]: # (TODO: Social media something for our members to share)
+Celebrate your contribution and share it with your friends and followers by going to:  
 
-You can join our slack team in case you need any help or have any questions. [Join slack team](https://join.slack.com/t/firstcontributors/shared_invite/enQtMzE1MTYwNzI3ODQ0LTZiMDA2OGI2NTYyNjM1MTFiNTc4YTRhZTg4OWZjMzA0ZWZmY2UxYzVkMzI1ZmVmOWI4ODdkZWQwNTM2NDVmNjY).
+[//]: # (TODO: slack invite to MSC)
+You can join our slack team in case you need any help or have any questions. [Join slack team]
 
+[//]: # (TODO: MSC-curated contribution list)
 Now let's get you started with contributing to other projects. We've compiled a list of projects with easy issues you can get started on. Check out [the list of projects in web app](https://roshanjossey.github.io/first-contributions/#project-list).
-
-### [Additional material](additional-material/git_workflow_senarios/additional-material.md)
-
-
-## Tutorials Using Other Tools
-
-|<a href="README.md"><img alt="Command Line" src="http://cdn.osxdaily.com/wp-content/uploads/2014/08/terminal-icon-osx-150x150.png" width="100"></a>|<a href="github-windows-vs2017-tutorial.md"><img alt="Visual Studio 2017" src="https://upload.wikimedia.org/wikipedia/commons/c/cd/Visual_Studio_2017_Logo.svg" width="100"></a>|<a href="gitkraken-tutorial.md"><img alt="GitKraken" src="/assets/gk-icon.png" width="100"></a>|<a href="github-windows-vs-code-tutorial.md"><img alt="VS Code" src="https://upload.wikimedia.org/wikipedia/commons/2/2d/Visual_Studio_Code_1.18_icon.svg" width=100></a>|<a href="sourcetree-macos-tutorial.md"><img alt="Sourcetree App" src="https://wac-cdn.atlassian.com/dam/jcr:81b15cde-be2e-4f4a-8af7-9436f4a1b431/Sourcetree-icon-blue.svg" width=100></a>|<a href="github-windows-intellij-tutorial.md"><img alt="IntelliJ IDEA" src="https://upload.wikimedia.org/wikipedia/commons/d/d5/IntelliJ_IDEA_Logo.svg" width=100></a>|
-|---|---|---|---|---|---|
-|[Command Line](README.md)|[Visual Studio 2017](github-windows-vs2017-tutorial.md)|[GitKraken](gitkraken-tutorial.md)|[Visual Studio Code](github-windows-vs-code-tutorial.md)|[Atlassian Sourcetree](sourcetree-macos-tutorial.md)|[IntelliJ IDEA](github-windows-intellij-tutorial.md)|
-
-## Self-Promotion
-
-If you liked this project, star it on [GitHub](https://github.com/Roshanjossey/first-contributions).
-If you're feeling especially charitable, follow [Roshan](https://roshanjossey.github.io/) on
-[Twitter](https://twitter.com/sudo__bangbang) and
-[GitHub](https://github.com/roshanjossey).
-
-<a href="http://saasgrids.com"> <img alt="http://saasgrids.com" src="assets/saasgrids-banner.png" width="500"></a>

--- a/github-desktop-tutorial.md
+++ b/github-desktop-tutorial.md
@@ -1,10 +1,5 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
-[<img align="right" width="150" src="assets/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/enQtNjkxNzQwNzA2MTMwLTVhMWJjNjg2ODRlNWZhNjIzYjgwNDIyZWYwZjhjYTQ4OTBjMWM0MmFhZDUxNzBiYzczMGNiYzcxNjkzZDZlMDM)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-
-
-
-# First Contributions
 
 |<img alt="GitHub Desktop" src="https://desktop.github.com/images/desktop-icon.svg" width="200">|GitHub Desktop Edition|
 |---|---|

--- a/github-desktop-tutorial.md
+++ b/github-desktop-tutorial.md
@@ -1,7 +1,7 @@
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://github.com/ellerbrock/open-source-badges/)
 [<img align="right" width="150" src="assets/join-slack-team.png">](https://join.slack.com/t/firstcontributors/shared_invite/enQtNjkxNzQwNzA2MTMwLTVhMWJjNjg2ODRlNWZhNjIzYjgwNDIyZWYwZjhjYTQ4OTBjMWM0MmFhZDUxNzBiYzczMGNiYzcxNjkzZDZlMDM)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Open Source Helpers](https://www.codetriage.com/roshanjossey/first-contributions/badges/users.svg)](https://www.codetriage.com/roshanjossey/first-contributions)
+
 
 
 # First Contributions

--- a/github-desktop-tutorial.md
+++ b/github-desktop-tutorial.md
@@ -27,7 +27,7 @@ This will create of copy of this repository in your account.
 * After you click on "Open GitHubDesktop.exe" the contents will be downloaded to your computer.
 <img style="left;" src="assets/dt1-downloaded.png" alt="clone this repository" />
 
-* Now you have copied the contents of the first-contributions repository in github to your computer.
+* Now you have copied the contents of the hacktoberfest_2020 repository in github to your computer.
 
 ## 4. Create a branch
 

--- a/github-desktop-tutorial.md
+++ b/github-desktop-tutorial.md
@@ -45,6 +45,7 @@ This will create of copy of this repository in your account.
 
 * Example: If your GitHub handle is jamessmith, It should look like this:
 
+[//]: # (TODO: new image of what ours will look like)
 <img style="left;" src="assets/dt1-status.png" alt="check status" />
 
 * You can see that there are changes to Contributors.md and they have been added to the Github Desktop.


### PR DESCRIPTION
I wanted to kind of separate out the tutorials for command line and GitHub desktop.  The way I have it now eliminates the need for a Contributing.md file, but we can further change this to make the README even more general and copy the contributing information on the Contributing file.  Let me know what you think, I'm open to changing this up again! 